### PR TITLE
Updated home dir reference in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_cache:
 
 cache:
   directories:
-    - ~/.m2
+    - $HOME/.m2
 
 script: ./mvnw clean install site --batch-mode --show-version
 


### PR DESCRIPTION
Changed all references to the more verbose `$HOME` rather than `~`.