### PR TITLE
Renamed Kotlin version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,10 @@
   </modules>
 
   <properties>
-    <dependencies.kotlin.version>1.1.1</dependencies.kotlin.version>
     <dependencies.spring-boot.version>1.5.2.RELEASE</dependencies.spring-boot.version>
     <dependencies.spring.version>4.3.7.RELEASE</dependencies.spring.version>
     <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+    <kotlin.version>1.1.1</kotlin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -68,7 +68,7 @@
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib-jre8</artifactId>
-        <version>${dependencies.kotlin.version}</version>
+        <version>${kotlin.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -143,7 +143,7 @@
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-test-junit</artifactId>
-        <version>${dependencies.kotlin.version}</version>
+        <version>${kotlin.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -257,7 +257,7 @@
         <plugin>
           <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-maven-plugin</artifactId>
-          <version>${dependencies.kotlin.version}</version>
+          <version>${kotlin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Since it's more than just the dependency version it makes sense to remove the 'dependencies' prefix.