### PR TITLE
Fixed null handling for JacksonObjectReader

### DIFF
--- a/com.gantsign.restrulz.jackson/src/test/kotlin/com/gantsign/restrulz/jackson/reader/EmptyReader.kt
+++ b/com.gantsign.restrulz.jackson/src/test/kotlin/com/gantsign/restrulz/jackson/reader/EmptyReader.kt
@@ -24,13 +24,10 @@ import com.gantsign.restrulz.jackson.Empty
 
 object EmptyReader : JacksonObjectReader<Empty>() {
 
-    override fun readObject(parser: ValidationHandlingJsonParser): Empty? {
+    override fun readRequiredObject(parser: ValidationHandlingJsonParser): Empty? {
         // Sanity check: verify that we got "Json Object":
         val startObject = parser.currentToken()
         when (startObject) {
-            JsonToken.VALUE_NULL -> {
-                return null
-            }
             JsonToken.START_OBJECT -> {
                 // continue
             }

--- a/com.gantsign.restrulz.jackson/src/test/kotlin/com/gantsign/restrulz/jackson/reader/JacksonObjectReaderTest.kt
+++ b/com.gantsign.restrulz.jackson/src/test/kotlin/com/gantsign/restrulz/jackson/reader/JacksonObjectReaderTest.kt
@@ -30,6 +30,7 @@ import java.io.InputStream
 import java.nio.charset.StandardCharsets.UTF_8
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class JacksonObjectReaderTest {
@@ -40,6 +41,26 @@ class JacksonObjectReaderTest {
 
     fun String.toInputStream(): InputStream {
         return ByteArrayInputStream(this.toByteArray(UTF_8))
+    }
+
+    @Test
+    fun testReadOptionalObject() {
+        val jsonFactory = JsonFactory()
+        val parser = ValidationHandlingJsonParser(jsonFactory.createParser("{}"))
+        parser.nextToken()
+
+        val empty: Empty? = EmptyReader.readOptionalObject(parser)
+        assertNotNull(empty)
+    }
+
+    @Test
+    fun testReadOptionalObjectWithNull() {
+        val jsonFactory = JsonFactory()
+        val parser = ValidationHandlingJsonParser(jsonFactory.createParser("null"))
+        parser.nextToken()
+
+        val empty: Empty? = EmptyReader.readOptionalObject(parser)
+        assertNull(empty)
     }
 
     @Test
@@ -65,6 +86,26 @@ class JacksonObjectReaderTest {
     }
 
     @Test
+    fun testReadOptionalArray() {
+        val jsonFactory = JsonFactory()
+        val parser = ValidationHandlingJsonParser(jsonFactory.createParser("[{}]"))
+        parser.nextToken()
+
+        val list: List<Empty>? = EmptyReader.readOptionalArray(parser)
+        assertNotNull(list)
+    }
+
+    @Test
+    fun testReadOptionalArrayWithNull() {
+        val jsonFactory = JsonFactory()
+        val parser = ValidationHandlingJsonParser(jsonFactory.createParser("null"))
+        parser.nextToken()
+
+        val list: List<Empty>? = EmptyReader.readOptionalArray(parser)
+        assertNull(list)
+    }
+
+    @Test
     fun testReadArrayFromStream() {
         val values: List<Empty> = EmptyReader.readArray("[{},{}]".toInputStream())
         assertEquals(expected = 2, actual = values.size)
@@ -77,7 +118,7 @@ class JacksonObjectReaderTest {
 
         parser.nextToken()
 
-        EmptyReader.readArray(parser)
+        EmptyReader.readRequiredArray(parser)
 
         assertTrue(parser.hasValidationFailures)
         assertEquals(

--- a/com.gantsign.restrulz.spring.mvc/src/test/kotlin/com/gantsign/restrulz/spring/mvc/model/json/reader/impl/TestEntityReader.kt
+++ b/com.gantsign.restrulz.spring.mvc/src/test/kotlin/com/gantsign/restrulz/spring/mvc/model/json/reader/impl/TestEntityReader.kt
@@ -32,12 +32,9 @@ object TestEntityReader : JacksonObjectReader<TestEntity>() {
     private val log: Logger = LoggerFactory.getLogger(TestEntityReader::class.java)
     private val idIndex: Int = 0
 
-    override fun readObject(parser: ValidationHandlingJsonParser): TestEntity? {
+    override fun readRequiredObject(parser: ValidationHandlingJsonParser): TestEntity? {
         val startObject = parser.currentToken()
         when (startObject) {
-            JsonToken.VALUE_NULL -> {
-                return null
-            }
             JsonToken.START_OBJECT -> {
                 // continue
             }


### PR DESCRIPTION
Previously it was difficult to produce a validation error for required objects because you couldn't easily tell if the value was null due to a null value or a validation error.

There's now dedicated APIs for required objects and arrays that produce the necessary validation error for you.