### PR TITLE
Removed duplicate validation check

### DIFF
--- a/com.gantsign.restrulz.jackson/src/main/kotlin/com/gantsign/restrulz/jackson/reader/JacksonObjectReader.kt
+++ b/com.gantsign.restrulz.jackson/src/main/kotlin/com/gantsign/restrulz/jackson/reader/JacksonObjectReader.kt
@@ -94,10 +94,6 @@ abstract class JacksonObjectReader<out T> : JsonObjectReader<T> {
         val mutableList: MutableList<T> = mutableListOf()
         try {
             while (parser.nextToken() !== JsonToken.END_ARRAY) {
-                if (parser.currentToken === JsonToken.VALUE_NULL) {
-                    parser.handleValidationFailure("Expected ${JsonToken.START_OBJECT} but was ${parser.currentToken}")
-                    continue
-                }
 
                 val element = readRequiredObject(parser)
 


### PR DESCRIPTION
The validation is also performed by `readRequiredObject()`.