### PR TITLE
Renamed blankToEmpty() to blankOrNullToEmpty()

### DIFF
--- a/com.gantsign.restrulz.util/src/main/kotlin/com/gantsign/restrulz/util/string/package.kt
+++ b/com.gantsign.restrulz.util/src/main/kotlin/com/gantsign/restrulz/util/string/package.kt
@@ -22,13 +22,13 @@ package com.gantsign.restrulz.util.string
 /**
  * Returns this String if the string is non-null and non-blank otherwise returns empty string.
  */
-fun String?.blankToEmpty(): String {
+fun String?.blankOrNullToEmpty(): String {
     return if (this === null || this.isBlank()) "" else this
 }
 
 /**
- * Returns a new list where all the items in this list are mapped with [blankToEmpty].
+ * Returns a new list where all the items in this list are mapped with [blankOrNullToEmpty].
  */
-fun List<String>.blankToEmpty(): List<String> {
-    return this.map(String::blankToEmpty)
+fun List<String>.blankOrNullToEmpty(): List<String> {
+    return this.map(String::blankOrNullToEmpty)
 }

--- a/com.gantsign.restrulz.util/src/test/kotlin/com/gantsign/restrulz/util/string/PackageTest.kt
+++ b/com.gantsign.restrulz.util/src/test/kotlin/com/gantsign/restrulz/util/string/PackageTest.kt
@@ -26,41 +26,41 @@ import kotlin.test.assertEquals
 class PackageTest {
 
     @Test
-    fun testStringBlankToEmptyWithNonBlank() {
+    fun testStringBlankOrNullToEmptyWithNonBlank() {
         val expected = "a"
-        val actual = expected.blankToEmpty()
+        val actual = expected.blankOrNullToEmpty()
 
         assertSame(expected, actual)
     }
 
     @Test
-    fun testStringBlankToEmptyWithBlank() {
+    fun testStringBlankOrNullToEmptyWithBlank() {
         val expected = ""
-        val actual = " ".blankToEmpty()
+        val actual = " ".blankOrNullToEmpty()
 
         assertEquals(expected, actual)
     }
 
     @Test
-    fun testStringBlankToEmptyWithNull() {
+    fun testStringBlankOrNullToEmptyWithNull() {
         val expected = ""
-        val actual = (null as String?).blankToEmpty()
+        val actual = (null as String?).blankOrNullToEmpty()
 
         assertEquals(expected, actual)
     }
 
     @Test
-    fun testListBlankToEmptyWithNonBlank() {
+    fun testListBlankOrNullToEmptyWithNonBlank() {
         val expected = listOf("a")
-        val actual = expected.blankToEmpty()
+        val actual = expected.blankOrNullToEmpty()
 
         assertEquals(expected, actual)
     }
 
     @Test
-    fun testListBlankToEmptyWithBlank() {
+    fun testListBlankOrNullToEmptyWithBlank() {
         val expected = listOf("")
-        val actual = listOf(" ").blankToEmpty()
+        val actual = listOf(" ").blankOrNullToEmpty()
 
         assertEquals(expected, actual)
     }


### PR DESCRIPTION
After consideration I think accuracy is more important than conciseness in this case.